### PR TITLE
Make panel border wider

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -149,7 +149,7 @@ class SolarConstants:
     # Specs for this panel: https://midsummerwholesale.co.uk/buy/longi-solar/longi-355-hib
     PANEL_HEIGHT_M = 1.755
     PANEL_WIDTH_M = 1.038
-    PANEL_BORDER_M = 0.5  # gap to leave at side of roof (so 25cm each side)
+    PANEL_BORDER_M = 0.6  # gap to leave at side of roof (so 30cm each side)
     PANEL_AREA = PANEL_HEIGHT_M * PANEL_WIDTH_M
     KW_PEAK_PER_PANEL = 0.355  # output with incident radiation of 1kW/m2
     # Panel dimensions and kW_peak from https://www.greenmatch.co.uk/blog/how-many-solar-panels-do-i-need

--- a/src/constants.py
+++ b/src/constants.py
@@ -146,11 +146,12 @@ class SolarConstants:
     DEFAULT_LONG = -0.118092
 
     ROOF_PITCH_DEGREES = 30
-    PANEL_HEIGHT_M = 1.67
-    PANEL_WIDTH_M = 1.0
+    # Specs for this panel: https://midsummerwholesale.co.uk/buy/longi-solar/longi-355-hib
+    PANEL_HEIGHT_M = 1.755
+    PANEL_WIDTH_M = 1.038
     PANEL_BORDER_M = 0.5  # gap to leave at side of roof (so 25cm each side)
     PANEL_AREA = PANEL_HEIGHT_M * PANEL_WIDTH_M
-    KW_PEAK_PER_PANEL = 0.30  # output with incident radiation of 1kW/m2
+    KW_PEAK_PER_PANEL = 0.355  # output with incident radiation of 1kW/m2
     # Panel dimensions and kW_peak from https://www.greenmatch.co.uk/blog/how-many-solar-panels-do-i-need
 
     PERCENT_SQUARE_USABLE = 0.8  # complete guess

--- a/src/constants.py
+++ b/src/constants.py
@@ -148,7 +148,7 @@ class SolarConstants:
     ROOF_PITCH_DEGREES = 30
     PANEL_HEIGHT_M = 1.67
     PANEL_WIDTH_M = 1.0
-    PANEL_BORDER_M = 0.3  # gap to leave at side of roof (so 15cm each side)
+    PANEL_BORDER_M = 0.5  # gap to leave at side of roof (so 25cm each side)
     PANEL_AREA = PANEL_HEIGHT_M * PANEL_WIDTH_M
     KW_PEAK_PER_PANEL = 0.30  # output with incident radiation of 1kW/m2
     # Panel dimensions and kW_peak from https://www.greenmatch.co.uk/blog/how-many-solar-panels-do-i-need

--- a/src/solar.py
+++ b/src/solar.py
@@ -69,6 +69,7 @@ class Solar:
         return value / np.cos(np.radians(self.pitch))
 
     def get_number_of_panels_from_polygons(self) -> int:
+        print(self.roof_area)
         numbers = []
         for polygon in self.polygons:
             if len(polygon.dimensions) != 4:  # if not roughly rectangular
@@ -76,7 +77,9 @@ class Solar:
             else:
                 number_this_polygon = self.max_number_of_panels_in_a_rectangle(polygon)
             numbers.append(number_this_polygon)
+        print(f"number this polygon: {number_this_polygon}")
         all_panels = sum(numbers)
+        print(f"number all polygons: {all_panels}")
         return all_panels
 
     def get_number_of_panels_from_polygon_area(self, polygon: Polygon) -> int:
@@ -89,7 +92,9 @@ class Solar:
     def max_number_of_panels_in_a_rectangle(self, polygon) -> int:
         """ Assume shape is rectangular. Try panels in either orientation"""
         roof_height = polygon.average_plan_height / np.cos(np.radians(self.pitch))
+        print("long side up roof")
         option_1 = self.number_of_panels_in_rectangle(side_1=polygon.average_width, side_2=roof_height)
+        print("short side up roof")
         option_2 = self.number_of_panels_in_rectangle(side_1=roof_height, side_2=polygon.average_width)
         number = max(option_1, option_2)
         return number
@@ -102,6 +107,7 @@ class Solar:
             rows_axis_1 = floor((side_1 - SolarConstants.PANEL_BORDER_M) / SolarConstants.PANEL_WIDTH_M)
             rows_axis_2 = floor((side_2 - SolarConstants.PANEL_BORDER_M)/SolarConstants.PANEL_HEIGHT_M)
             number = rows_axis_1 * rows_axis_2
+            print(f"{rows_axis_1} by {rows_axis_2}")
         return number
 
     @property

--- a/src/solar.py
+++ b/src/solar.py
@@ -73,13 +73,16 @@ class Solar:
         numbers = []
         for polygon in self.polygons:
             if len(polygon.dimensions) != 4:  # if not roughly rectangular
+                print("Calculated based on area")
                 number_this_polygon = self.get_number_of_panels_from_polygon_area(polygon)
             else:
+                print("Calculated based on side lengths")
                 number_this_polygon = self.max_number_of_panels_in_a_rectangle(polygon)
             numbers.append(number_this_polygon)
         print(f"number this polygon: {number_this_polygon}")
         all_panels = sum(numbers)
         print(f"number all polygons: {all_panels}")
+        print(f"number based on area: {self.get_number_of_panels_from_polygon_area(polygon)}")
         return all_panels
 
     def get_number_of_panels_from_polygon_area(self, polygon: Polygon) -> int:
@@ -92,6 +95,7 @@ class Solar:
     def max_number_of_panels_in_a_rectangle(self, polygon) -> int:
         """ Assume shape is rectangular. Try panels in either orientation"""
         roof_height = polygon.average_plan_height / np.cos(np.radians(self.pitch))
+        print(f"roof height = {roof_height}, roof_width = {polygon.average_width}")
         print("long side up roof")
         option_1 = self.number_of_panels_in_rectangle(side_1=polygon.average_width, side_2=roof_height)
         print("short side up roof")

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -40,7 +40,7 @@ def test_get_number_of_panels_returns_expected_type_and_value():
                                 polygons=[TEST_POLYGONS[0]],
                                 pitch=pitch)
     assert isinstance(solar_install.number_of_panels, int)
-    assert solar_install.number_of_panels == 2
+    assert solar_install.number_of_panels == 1
     assert solar_install.number_of_panels != solar_install.get_number_of_panels_from_polygon_area(TEST_POLYGONS[0])
 
 
@@ -60,9 +60,9 @@ def test_get_hourly_radiation_from_eu_api_returns_expected_annual_sum():
     solar_install.number_of_panels = 10  # overwrite for test
     assert solar_install.number_of_panels_has_been_overwritten is True
 
-    assert solar_install.peak_capacity_kw_out_per_kw_in_per_m2 == 3.0
+    assert solar_install.peak_capacity_kw_out_per_kw_in_per_m2 == 10 * SolarConstants.KW_PEAK_PER_PANEL
     pv_power_kw = solar_install.get_hourly_radiation_from_eu_api()
-    ANNUAL_KWH = 2326.95354
+    ANNUAL_KWH = 2753.56156
     np.testing.assert_almost_equal(pv_power_kw.sum(), ANNUAL_KWH)
     np.testing.assert_almost_equal(solar_install.generation.exported.annual_sum_kwh, ANNUAL_KWH)
     np.testing.assert_almost_equal(solar_install.generation.overall.annual_sum_kwh, - ANNUAL_KWH)


### PR DESCRIPTION
We were consistently overestimating how many panels could fit on a roof, so I've:
-  made the panel border bigger. This seems to vary enormously in real installs, I've chosen a middle ground. 
-  updated the panel dimensions to those for a real panel

Also added some print statements to make it easier to debug/understand the estimates. 