### PR TITLE
Solar border depends on dims

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -149,7 +149,8 @@ class SolarConstants:
     # Specs for this panel: https://midsummerwholesale.co.uk/buy/longi-solar/longi-355-hib
     PANEL_HEIGHT_M = 1.755
     PANEL_WIDTH_M = 1.038
-    PANEL_BORDER_M = 0.6  # gap to leave at side of roof (so 30cm each side)
+    SMALL_PANEL_BORDER_M = 0.6  # gap to leave at side of roof (so 30cm each side)
+    BIG_PANEL_BORDER_M = 0.8  # gap to leave at side of roof for bigger roofs (so 40cm each side)
     PANEL_AREA = PANEL_HEIGHT_M * PANEL_WIDTH_M
     KW_PEAK_PER_PANEL = 0.355  # output with incident radiation of 1kW/m2
     # Panel dimensions and kW_peak from https://www.greenmatch.co.uk/blog/how-many-solar-panels-do-i-need

--- a/src/constants.py
+++ b/src/constants.py
@@ -146,13 +146,13 @@ class SolarConstants:
     DEFAULT_LONG = -0.118092
 
     ROOF_PITCH_DEGREES = 30
-    # Specs for this panel: https://midsummerwholesale.co.uk/buy/longi-solar/longi-355-hib
-    PANEL_HEIGHT_M = 1.755
-    PANEL_WIDTH_M = 1.038
+    # Specs for this panel: https://midsummerwholesale.co.uk/buy/longi-solar/longi-lr5hib-400w
+    PANEL_HEIGHT_M = 1.722
+    PANEL_WIDTH_M = 1.134
     SMALL_PANEL_BORDER_M = 0.6  # gap to leave at side of roof (so 30cm each side)
     BIG_PANEL_BORDER_M = 0.8  # gap to leave at side of roof for bigger roofs (so 40cm each side)
     PANEL_AREA = PANEL_HEIGHT_M * PANEL_WIDTH_M
-    KW_PEAK_PER_PANEL = 0.355  # output with incident radiation of 1kW/m2
+    KW_PEAK_PER_PANEL = 0.400  # output with incident radiation of 1kW/m2
     # Panel dimensions and kW_peak from https://www.greenmatch.co.uk/blog/how-many-solar-panels-do-i-need
 
     PERCENT_SQUARE_USABLE = 0.8  # complete guess

--- a/src/consumption.py
+++ b/src/consumption.py
@@ -86,10 +86,7 @@ class Consumption:
         return exported
 
     def add(self, other: 'Consumption') -> 'Consumption':
-        if self.fuel == other.fuel:
-            combined_overall_consumption = self.overall.add(other.overall)
-            combined_consumption = Consumption(hourly_profile_kwh=combined_overall_consumption.hourly_profile_kwh,
-                                               fuel=self.fuel)
-        else:
-            raise ValueError("The fuel of the two consumptions must match")
+        combined_overall_consumption = self.overall.add(other.overall)
+        combined_consumption = Consumption(hourly_profile_kwh=combined_overall_consumption.hourly_profile_kwh,
+                                           fuel=self.fuel)
         return combined_consumption

--- a/src/solar.py
+++ b/src/solar.py
@@ -96,20 +96,27 @@ class Solar:
         """ Assume shape is rectangular. Try panels in either orientation"""
         roof_height = polygon.average_plan_height / np.cos(np.radians(self.pitch))
         print(f"roof height = {roof_height}, roof_width = {polygon.average_width}")
+        # Typically installers leave a bigger border on big roofs. Increase border if fit more than 2 rows heightwise
+        if roof_height >= 2 * (SolarConstants.SMALL_PANEL_BORDER_M + SolarConstants.PANEL_HEIGHT_M):
+            border_to_use = SolarConstants.BIG_PANEL_BORDER_M
+        else:
+            border_to_use = SolarConstants.SMALL_PANEL_BORDER_M
         print("long side up roof")
-        option_1 = self.number_of_panels_in_rectangle(side_1=polygon.average_width, side_2=roof_height)
+        option_1 = self.number_of_panels_in_rectangle(side_1=polygon.average_width, side_2=roof_height,
+                                                      border=border_to_use)
         print("short side up roof")
-        option_2 = self.number_of_panels_in_rectangle(side_1=roof_height, side_2=polygon.average_width)
+        option_2 = self.number_of_panels_in_rectangle(side_1=roof_height, side_2=polygon.average_width,
+                                                      border=border_to_use)
         number = max(option_1, option_2)
         return number
 
     @staticmethod
-    def number_of_panels_in_rectangle(side_1: float, side_2: float) -> int:
-        if side_1 < SolarConstants.PANEL_BORDER_M or side_2 < SolarConstants.PANEL_BORDER_M:
+    def number_of_panels_in_rectangle(side_1: float, side_2: float, border: float) -> int:
+        if side_1 < SolarConstants.SMALL_PANEL_BORDER_M or side_2 < SolarConstants.SMALL_PANEL_BORDER_M:
             number = 0
         else:
-            rows_axis_1 = floor((side_1 - SolarConstants.PANEL_BORDER_M) / SolarConstants.PANEL_WIDTH_M)
-            rows_axis_2 = floor((side_2 - SolarConstants.PANEL_BORDER_M)/SolarConstants.PANEL_HEIGHT_M)
+            rows_axis_1 = floor((side_1 - border) / SolarConstants.PANEL_WIDTH_M)
+            rows_axis_2 = floor((side_2 - border) / SolarConstants.PANEL_HEIGHT_M)
             number = rows_axis_1 * rows_axis_2
             print(f"{rows_axis_1} by {rows_axis_2}")
         return number

--- a/src/solar.py
+++ b/src/solar.py
@@ -96,11 +96,13 @@ class Solar:
         """ Assume shape is rectangular. Try panels in either orientation"""
         roof_height = polygon.average_plan_height / np.cos(np.radians(self.pitch))
         print(f"roof height = {roof_height}, roof_width = {polygon.average_width}")
-        # Typically installers leave a bigger border on big roofs. Increase border if fit more than 2 rows heightwise
+        # Typically, installers leave a bigger border on big roofs. Increase border if fit more than 2 rows height-wise
         if roof_height >= 2 * (SolarConstants.SMALL_PANEL_BORDER_M + SolarConstants.PANEL_HEIGHT_M):
             border_to_use = SolarConstants.BIG_PANEL_BORDER_M
+            print("Using big border")
         else:
             border_to_use = SolarConstants.SMALL_PANEL_BORDER_M
+            print("Using small border")
         print("long side up roof")
         option_1 = self.number_of_panels_in_rectangle(side_1=polygon.average_width, side_2=roof_height,
                                                       border=border_to_use)

--- a/src/solar.py
+++ b/src/solar.py
@@ -114,7 +114,7 @@ class Solar:
 
     @staticmethod
     def number_of_panels_in_rectangle(side_1: float, side_2: float, border: float) -> int:
-        if side_1 < SolarConstants.SMALL_PANEL_BORDER_M or side_2 < SolarConstants.SMALL_PANEL_BORDER_M:
+        if side_1 < border or side_2 < border:
             number = 0
         else:
             rows_axis_1 = floor((side_1 - border) / SolarConstants.PANEL_WIDTH_M)

--- a/src/solar_questions.py
+++ b/src/solar_questions.py
@@ -27,7 +27,7 @@ def render() -> "Solar":
     try:
         polygons = roof.roof_mapper(800, 400)  # figure out how to save state here
     except KeyError:
-        st.error("You've used a drawing tool we don't support, sorry! Please try with the ⭓ or ◼️ tools")
+        st.error("You've used a drawing tool we don't support, sorry! Please try with the ⭓ tool")
         polygons = None
 
     polygons = polygons if polygons else Solar.create_zero_area_instance().polygons

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -40,8 +40,8 @@ def test_get_number_of_panels_returns_expected_type_and_value():
                                 polygons=[TEST_POLYGONS[0]],
                                 pitch=pitch)
     assert isinstance(solar_install.number_of_panels, int)
-    assert solar_install.number_of_panels == 1
-    assert solar_install.number_of_panels != solar_install.get_number_of_panels_from_polygon_area(TEST_POLYGONS[0])
+    assert solar_install.number_of_panels == 2
+    assert solar_install.get_number_of_panels_from_polygon_area(TEST_POLYGONS[0]) == 2
 
 
 def test_peak_capacity_kw_out_per_kw_in_per_m2_returns_expected_type_and_value():
@@ -62,7 +62,7 @@ def test_get_hourly_radiation_from_eu_api_returns_expected_annual_sum():
 
     assert solar_install.peak_capacity_kw_out_per_kw_in_per_m2 == 10 * SolarConstants.KW_PEAK_PER_PANEL
     pv_power_kw = solar_install.get_hourly_radiation_from_eu_api()
-    ANNUAL_KWH = 2753.56156
+    ANNUAL_KWH = 3102.6047200000003
     np.testing.assert_almost_equal(pv_power_kw.sum(), ANNUAL_KWH)
     np.testing.assert_almost_equal(solar_install.generation.exported.annual_sum_kwh, ANNUAL_KWH)
     np.testing.assert_almost_equal(solar_install.generation.overall.annual_sum_kwh, - ANNUAL_KWH)


### PR DESCRIPTION
If roof is big enough to have more than 2 rows height-wise, increase the border to better reflect the norms for bigger roofs. Also update the panels used. 