### PR TITLE
Cost overwrites

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -106,14 +106,19 @@ DEFAULT_HEATING_CONSTANTS = {
 # https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/656866/BEIS_Update_of_Domestic_Cost_Assumptions_031017.pdf
 # https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1104051/CODE-Final-Report-WHOLE-FINAL-v20.pdf
 HEAT_PUMP_COSTS = {"Terrace": 10000, "Semi-detached": 11100, "Flat": 9100, "Detached": 13100}
-GAS_BOILER_COSTS = {"Terrace": 1800 * 10000/11100, "Semi-detached": 1800, "Flat": 1500, "Detached": 2200}
+GAS_BOILER_COSTS = {"Terrace": 1800 * 10000 / 11100, "Semi-detached": 1800, "Flat": 1500, "Detached": 2200}
 HEATING_SYSTEM_COSTS = {"Gas boiler": GAS_BOILER_COSTS,
                         "Heat pump": HEAT_PUMP_COSTS,
                         "Oil boiler": GAS_BOILER_COSTS,  # assume they are the same
                         "Direct electric": GAS_BOILER_COSTS
                         }
-HEAT_PUMP_GRANT = 5000  # Boiler upgrade scheme
+HEATING_SYSTEM_GRANTS = {"Gas boiler": 0,
+                         "Heat pump": 5000,  # Boiler upgrade scheme,
+                         "Oil boiler": 0,
+                         "Direct electric": 0
+                         }
 HEATING_SYSTEM_LIFETIME = 20
+
 
 # TODO: reference nesta tool: http://asf-hp-cost-demo-l-b-1046547218.eu-west-1.elb.amazonaws.com
 

--- a/src/house_questions.py
+++ b/src/house_questions.py
@@ -26,7 +26,7 @@ def render() -> "House":
     if st.session_state.heating_fuel_changed:
         house.tariffs = update_tariffs_for_new_heating_fuel(heating_fuel=house.heating_system.fuel,
                                                             tariffs=house.tariffs)
-    house = render_assumptions_sidebar(house=house)
+    house = render_house_assumptions_sidebar(house=house)
 
     render_results(house)
     return house
@@ -143,7 +143,7 @@ def update_tariffs_for_new_heating_fuel(heating_fuel: Fuel, tariffs: Dict[str, T
     return tariffs
 
 
-def render_assumptions_sidebar(house: House) -> House:
+def render_house_assumptions_sidebar(house: House) -> House:
     with st.sidebar:
         st.header("Assumptions")
         st.markdown(

--- a/src/house_questions.py
+++ b/src/house_questions.py
@@ -156,6 +156,7 @@ def render_house_assumptions_sidebar(house: House) -> House:
 
 
 def render_house_overwrite_options(house: House):
+    """ Split out because used on savings page and front page"""
     with st.expander("Baseline heating system"):
         house.heating_system = render_baseline_heating_system_overwrite_options(house=house)
     with st.expander("Energy use"):
@@ -168,8 +169,12 @@ def render_house_overwrite_options(house: House):
 
 def render_baseline_heating_system_overwrite_options(house: "House") -> "HeatingSystem":
     st.number_input(
-        label="Efficiency: ", min_value=0.1, max_value=8.0, value=st.session_state.baseline_heating_efficiency,
-        key="baseline_heating_efficiency_overwrite", on_change=overwrite_baseline_heating_efficiency_in_session_state)
+        label="Efficiency: ",
+        min_value=0.1,
+        max_value=8.0,
+        value=st.session_state.baseline_heating_efficiency,
+        key="baseline_heating_efficiency_overwrite",
+        on_change=overwrite_baseline_heating_efficiency_in_session_state)
 
     if st.session_state.baseline_heating_efficiency_changed:
         house.heating_system.efficiency = st.session_state.baseline_heating_efficiency

--- a/src/main.py
+++ b/src/main.py
@@ -13,13 +13,17 @@ st.set_page_config(page_title="Heat pump or Solar?",
 
 
 class YourHousePage(Page):
-    def render(self) -> dict:
-        return dict(house=house_questions.render())
+    def render(self):
+        house = house_questions.get_house_from_session_state_if_exists_or_create_default()
+        house = house_questions.render(house=house)
+        st.session_state.house = house
 
 
 class SolarPage(Page):
-    def render(self) -> dict:
-        return dict(solar=solar_questions.render())
+    def render(self):
+        solar_install = solar_questions.get_solar_install_from_session_state_if_exists_or_create_default()
+        solar_install = solar_questions.render(solar_install=solar_install)
+        st.session_state.solar_install = solar_install
 
 
 class ResultsPage(Page):
@@ -27,8 +31,14 @@ class ResultsPage(Page):
         # produce default version of house and solar for cases where user doesn't click through all the pages
         house = house_questions.get_house_from_session_state_if_exists_or_create_default()
         solar_install = solar_questions.get_solar_install_from_session_state_if_exists_or_create_default()
+        upgrade_heating = savings_outputs.get_upgrade_heating_from_session_state_if_exists_or_create_default()
 
-        savings_outputs.render(house=house, solar_install=solar_install)
+        house, solar_install, upgrade_heating = savings_outputs.render(house=house,
+                                                                       solar_install=solar_install,
+                                                                       upgrade_heating=upgrade_heating)
+        st.session_state.house = house
+        st.session_state.solar_install = solar_install
+        st.session_state.upgrade_heating = upgrade_heating
 
 
 class NextStepsPage(Page):

--- a/src/retrofit.py
+++ b/src/retrofit.py
@@ -43,7 +43,7 @@ class Retrofit:
         return payback
 
 
-def upgrade_buildings(baseline_house: 'House', upgrade_heating: 'HeatingSystem', solar_install: 'Solar'
+def upgrade_buildings(baseline_house: 'House', solar_install: 'Solar', upgrade_heating: 'HeatingSystem'
                       ) -> Tuple['House', 'House', 'House']:
     hp_house = copy.deepcopy(baseline_house)  # do after modifications so modifications flow through
     hp_house.heating_system = upgrade_heating
@@ -54,7 +54,12 @@ def upgrade_buildings(baseline_house: 'House', upgrade_heating: 'HeatingSystem',
 
     both_house = copy.deepcopy(hp_house)
     both_house.solar_install = solar_install
-    return hp_house, solar_house, both_house
+
+    assert (hp_house.consumption_per_fuel['electricity'].overall.annual_sum_kwh -
+            hp_house.heating_consumption.overall.annual_sum_kwh
+            - hp_house.electricity_consumption_excluding_heating.overall.annual_sum_kwh) < 0.1
+
+    return solar_house, hp_house, both_house
 
 
 def generate_all_retrofit_cases(baseline_house: 'House', solar_house: 'House', hp_house: 'House',

--- a/src/retrofit.py
+++ b/src/retrofit.py
@@ -47,7 +47,7 @@ def upgrade_buildings(baseline_house: 'House', solar_install: 'Solar', upgrade_h
                       ) -> Tuple['House', 'House', 'House']:
     hp_house = copy.deepcopy(baseline_house)  # do after modifications so modifications flow through
     hp_house.clear_cost_overwrite()  # so that changes in baseline cost don't flow through into hp_house
-    hp_house.heating_system = upgrade_heating
+    hp_house.heating_system = upgrade_heating  # means that cost overwrites here do not persist
 
     solar_house = copy.deepcopy(baseline_house)
     solar_house.solar_install = solar_install

--- a/src/retrofit.py
+++ b/src/retrofit.py
@@ -32,7 +32,7 @@ class Retrofit:
 
     @property
     def incremental_cost(self):
-        return self.upgrade_house.upfront_cost - self.baseline_house.upfront_cost
+        return self.upgrade_house.upfront_cost_after_grants - self.baseline_house.upfront_cost
 
     @property
     def simple_payback(self) -> float:
@@ -47,7 +47,6 @@ def upgrade_buildings(baseline_house: 'House', solar_install: 'Solar', upgrade_h
                       ) -> Tuple['House', 'House', 'House']:
     hp_house = copy.deepcopy(baseline_house)  # do after modifications so modifications flow through
     hp_house.heating_system = upgrade_heating
-    print("setting up heat pump house")
 
     solar_house = copy.deepcopy(baseline_house)
     solar_house.solar_install = solar_install

--- a/src/retrofit.py
+++ b/src/retrofit.py
@@ -43,17 +43,17 @@ class Retrofit:
         return payback
 
 
-def upgrade_buildings(baseline_house: 'House', upgrade_heating: 'HeatingSystem', upgrade_solar: 'Solar'
+def upgrade_buildings(baseline_house: 'House', upgrade_heating: 'HeatingSystem', solar_install: 'Solar'
                       ) -> Tuple['House', 'House', 'House']:
     hp_house = copy.deepcopy(baseline_house)  # do after modifications so modifications flow through
     hp_house.heating_system = upgrade_heating
     print("setting up heat pump house")
 
     solar_house = copy.deepcopy(baseline_house)
-    solar_house.solar_install = upgrade_solar
+    solar_house.solar_install = solar_install
 
     both_house = copy.deepcopy(hp_house)
-    both_house.solar_install = upgrade_solar
+    both_house.solar_install = solar_install
     return hp_house, solar_house, both_house
 
 

--- a/src/retrofit.py
+++ b/src/retrofit.py
@@ -46,12 +46,14 @@ class Retrofit:
 def upgrade_buildings(baseline_house: 'House', solar_install: 'Solar', upgrade_heating: 'HeatingSystem'
                       ) -> Tuple['House', 'House', 'House']:
     hp_house = copy.deepcopy(baseline_house)  # do after modifications so modifications flow through
+    hp_house.clear_cost_overwrite()  # so that changes in baseline cost don't flow through into hp_house
     hp_house.heating_system = upgrade_heating
 
     solar_house = copy.deepcopy(baseline_house)
     solar_house.solar_install = solar_install
 
     both_house = copy.deepcopy(hp_house)
+    both_house.clear_cost_overwrite()  # so that changes in baseline cost don't flow through into both_house
     both_house.solar_install = solar_install
 
     assert (hp_house.consumption_per_fuel['electricity'].overall.annual_sum_kwh -

--- a/src/savings_outputs.py
+++ b/src/savings_outputs.py
@@ -143,7 +143,6 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
         on_change=overwrite_baseline_heating_costs_in_session_state)
 
     if st.session_state.baseline_heating_cost_overwritten:
-        print("Behaves as if baseline heating cost overwritten")
         house.heating_system_upfront_cost = st.session_state.baseline_heating_cost
         solar_house.heating_system_upfront_cost = st.session_state.baseline_heating_cost
         st.session_state.baseline_heating_cost_overwritten = False
@@ -166,10 +165,13 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
         st.session_state.solar_cost_overwritten = False
 
     if "heat_pump_cost" not in st.session_state or st.session_state.upgrade_heating_system_cost_needs_resetting:
-        hp_house.clear_cost_overwrite()
-        st.session_state.heat_pump_cost = hp_house.upfront_cost
+        hp_house.clear_cost_overwrite()  # shouldn't currently be necessary because remade when this page renders
+        st.session_state.heat_pump_cost = hp_house.heating_system_upfront_cost
         st.session_state.heat_pump_cost_overwritten = False
         st.session_state.upgrade_heating_system_cost_needs_resetting = False
+    else:  # hp house gets remade each time savings page renders so the overwrite is lost
+        hp_house.heating_system_upfront_cost = st.session_state.heat_pump_cost
+        both_house.heating_system_upfront_cost = st.session_state.heat_pump_cost
 
     st.number_input(
         label="Heat pump cost (without grants)",

--- a/src/savings_outputs.py
+++ b/src/savings_outputs.py
@@ -6,6 +6,7 @@ import streamlit as st
 
 import house_questions
 import retrofit
+import solar_questions
 from building_model import *
 from constants import CLASS_NAME_OF_SIDEBAR_DIV
 from solar import Solar
@@ -72,8 +73,11 @@ def render_heat_pump_overwrite_options() -> HeatingSystem:
         on_change=overwrite_upgrade_heating_efficiency_in_session_state)
 
     if st.session_state.upgrade_heating_efficiency_overwritten:
+        print("Behaves as if heating efficiency overwritten")
         upgrade_heating.efficiency = st.session_state.upgrade_heating_efficiency
         st.session_state.upgrade_heating_efficiency_overwritten = False
+
+    st.session_state["page_state"]["upgrade_heating"] = dict(upgrade_heating=upgrade_heating)
 
     st.caption(
         "The efficiency of your heat pump depends on how well the system is designed and how low a flow "
@@ -131,15 +135,16 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
         max_value=30000,
         value=st.session_state.baseline_heating_cost,
         key="baseline_heating_cost_overwrite",
-        on_change=flag_that_baseline_heating_cost_overwritten)
+        on_change=overwrite_baseline_heating_costs_in_session_state)
 
     if st.session_state.baseline_heating_cost_overwritten:
+        print("Behaves as if baseline heating cost overwritten")
         house.heating_system_upfront_cost = st.session_state.baseline_heating_cost
         solar_house.heating_system_upfront_cost = st.session_state.baseline_heating_cost
         st.session_state.baseline_heating_cost_overwritten = False
 
     if "solar_cost" not in st.session_state:
-        st.session_state.solar_cost = solar_house.solar_install.upfront_cost
+        solar_questions.write_solar_cost_to_session_state(solar_install=solar_house.solar_install)
         st.session_state.solar_cost_overwritten = False
 
     st.number_input(
@@ -148,9 +153,10 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
         max_value=30000,
         value=st.session_state.solar_cost,
         key="solar_cost_overwrite",
-        on_change=flag_that_solar_cost_overwritten)
+        on_change=overwrite_solar_costs_in_session_state)
 
     if st.session_state.solar_cost_overwritten:
+        print("Behaves as if solar cost overwritten")
         solar_house.solar_install.upfront_cost = st.session_state.solar_cost
         both_house.solar_install.upfront_cost = st.session_state.solar_cost
         st.session_state.solar_cost_overwritten = False
@@ -165,9 +171,10 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
         max_value=30000,
         value=st.session_state.heat_pump_cost,
         key="heat_pump_cost_overwrite",
-        on_change=flag_that_heat_pump_cost_overwritten)
+        on_change=overwrite_heat_pump_costs_in_session_state)
 
     if st.session_state.heat_pump_cost_overwritten:
+        print("Behaves as if heating cost overwritten")
         hp_house.heating_system_upfront_cost = st.session_state.heat_pump_cost
         both_house.heating_system_upfront_cost = st.session_state.heat_pump_cost
         st.session_state.heat_pump_cost_overwritten = False
@@ -175,19 +182,19 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
     return house, solar_house, hp_house, both_house
 
 
-def flag_that_baseline_heating_cost_overwritten():
+def overwrite_baseline_heating_costs_in_session_state():
     st.session_state.baseline_heating_cost = st.session_state.baseline_heating_cost_overwrite
     st.session_state.baseline_heating_cost_overwritten = True
 
 
-def flag_that_heat_pump_cost_overwritten():
-    st.session_state.heat_pump_cost = st.session_state.heat_pump_cost_overwrite
-    st.session_state.heat_pump_cost_overwritten = True
-
-
-def flag_that_solar_cost_overwritten():
+def overwrite_solar_costs_in_session_state():
     st.session_state.solar_cost = st.session_state.solar_cost_overwrite
     st.session_state.solar_cost_overwritten = True
+
+
+def overwrite_heat_pump_costs_in_session_state():
+    st.session_state.heat_pump_cost = st.session_state.heat_pump_cost_overwrite
+    st.session_state.heat_pump_cost_overwritten = True
 
 
 def render_grant_overwrite_options(hp_house: House, both_house: House) -> Tuple[House, House]:
@@ -204,6 +211,7 @@ def render_grant_overwrite_options(hp_house: House, both_house: House) -> Tuple[
         on_change=flag_that_heat_pump_grant_value_overwritten)
 
     if st.session_state.heat_pump_grant_value_overwritten:
+        print("Behaves as if heat pump grant overwritten")
         hp_house.heating_system.grant = st.session_state.heat_pump_grant_value
         both_house.heating_system.grant = st.session_state.heat_pump_grant_value
         st.session_state.heat_pump_grant_value_overwritten = False

--- a/src/savings_outputs.py
+++ b/src/savings_outputs.py
@@ -181,29 +181,33 @@ def format_roi(roi: float) -> str:
 def render_and_update_improvement_options(solar_install: Solar) -> Tuple[HeatingSystem, Solar]:
     with st.expander("Solar PV assumptions "):
         solar_install = render_and_update_solar_inputs(solar_install=solar_install)
-
     with st.expander("Heat pump assumptions"):
-        if "upgrade_heating" not in st.session_state["page_state"]:
-            upgrade_heating = HeatingSystem.from_constants(
-                name="Heat pump", parameters=constants.DEFAULT_HEATING_CONSTANTS["Heat pump"]
-            )
-            st.session_state["page_state"]["upgrade_heating"] = dict(upgrade_heating=upgrade_heating)
-            # in case this page isn't always rendered
-        else:
-            upgrade_heating = st.session_state["page_state"]["upgrade_heating"]["upgrade_heating"]
-
-        upgrade_heating = overwrite_upgrade_heating_system_assumptions(heating_system=upgrade_heating)
-
-        st.caption(
-            "The efficiency of your heat pump depends on how well the system is designed and how low a flow "
-            "temperature it can run at. A COP of 3.6 or more is possible with a [high quality, low flow temperature "
-            "install](https://heatpumpmonitor.org).  \n  \n"
-            "A good installer is key to ensuring your heat pump runs efficiently. The [heat geek map"
-            "](https://www.heatgeek.com/find-a-heat-geek/) is a great place to start your search."
-        )
+        upgrade_heating = render_and_update_heat_pump_inputs()
     st.text("")
 
     return upgrade_heating, solar_install
+
+
+def render_and_update_heat_pump_inputs() -> HeatingSystem:
+    if "upgrade_heating" not in st.session_state["page_state"]:
+        upgrade_heating = HeatingSystem.from_constants(
+            name="Heat pump", parameters=constants.DEFAULT_HEATING_CONSTANTS["Heat pump"]
+        )
+        st.session_state["page_state"]["upgrade_heating"] = dict(upgrade_heating=upgrade_heating)
+        # in case this page isn't always rendered
+    else:
+        upgrade_heating = st.session_state["page_state"]["upgrade_heating"]["upgrade_heating"]
+
+    upgrade_heating = overwrite_upgrade_heating_system_assumptions(heating_system=upgrade_heating)
+
+    st.caption(
+        "The efficiency of your heat pump depends on how well the system is designed and how low a flow "
+        "temperature it can run at. A COP of 3.6 or more is possible with a [high quality, low flow temperature "
+        "install](https://heatpumpmonitor.org).  \n  \n"
+        "A good installer is key to ensuring your heat pump runs efficiently. The [heat geek map"
+        "](https://www.heatgeek.com/find-a-heat-geek/) is a great place to start your search."
+    )
+    return upgrade_heating
 
 
 def overwrite_upgrade_heating_system_assumptions(heating_system: "HeatingSystem") -> "HeatingSystem":

--- a/src/savings_outputs.py
+++ b/src/savings_outputs.py
@@ -29,10 +29,6 @@ def render(house: "House", solar_install: "Solar"):
     hp_house, solar_house, both_house = retrofit.upgrade_buildings(
         baseline_house=house, upgrade_heating=upgrade_heating, upgrade_solar=upgrade_solar
     )
-    assert hp_house.envelope.annual_heating_demand == house.envelope.annual_heating_demand
-    print("elec consumption", hp_house.consumption_per_fuel['electricity'].overall.annual_sum_kwh)
-    print("elec plus heating", hp_house.heating_consumption.overall.annual_sum_kwh
-          + hp_house.electricity_consumption_excluding_heating.overall.annual_sum_kwh)
     assert (hp_house.consumption_per_fuel['electricity'].overall.annual_sum_kwh -
             hp_house.heating_consumption.overall.annual_sum_kwh
             - hp_house.electricity_consumption_excluding_heating.overall.annual_sum_kwh) < 0.1

--- a/src/savings_outputs.py
+++ b/src/savings_outputs.py
@@ -145,7 +145,6 @@ def render_upfront_cost_overwrite_options(house: House, solar_house: House, hp_h
 
     if "solar_cost" not in st.session_state:
         solar_questions.write_solar_cost_to_session_state(solar_install=solar_house.solar_install)
-        st.session_state.solar_cost_overwritten = False
 
     st.number_input(
         label="Solar cost",
@@ -247,7 +246,7 @@ def render_results(house: House, solar_house: House, hp_house: House, both_house
             "</div>"
             "<div class='saving-maths'>"
             "<div>"
-            f"<p class='saving-maths-headline'> ~£{int(solar_house.solar_install.upfront_cost / 1000) * 1000:,d}</p>"
+            f"<p class='saving-maths-headline'> ~£{solar_house.solar_install.upfront_cost:,d}</p>"
             "<p class='saving-maths'> to install</p>"
             "</div>"
             "<div>"
@@ -266,7 +265,7 @@ def render_results(house: House, solar_house: House, hp_house: House, both_house
             f"<p> with a heat pump</p>"
             "<div class='saving-maths'>"
             "<div>"
-            f"<p class='saving-maths-headline'> ~£{int(hp_house.upfront_cost_after_grants / 1000) * 1000:,d}</p>"
+            f"<p class='saving-maths-headline'> ~£{hp_house.upfront_cost_after_grants:,d}</p>"
             "<p class='saving-maths'> to install</p>"
             "</div>"
             "<div>"
@@ -285,7 +284,7 @@ def render_results(house: House, solar_house: House, hp_house: House, both_house
             "<p> with both</p>"
             "<div class='saving-maths'>"
             "<div>"
-            f"<p class='saving-maths-headline'> ~£{int(both_house.upfront_cost_after_grants / 1000) * 1000:,d}</p>"
+            f"<p class='saving-maths-headline'> ~£{both_house.upfront_cost_after_grants:,d}</p>"
             "<p class='saving-maths'> to install</p>"
             "</div>"
             "<div>"

--- a/src/solar.py
+++ b/src/solar.py
@@ -99,7 +99,6 @@ class Solar:
         return value / np.cos(np.radians(self.pitch))
 
     def get_number_of_panels_from_polygons(self) -> int:
-        print(self.roof_area)
         numbers = []
         for polygon in self.polygons:
             if len(polygon.dimensions) != 4:  # if not roughly rectangular

--- a/src/solar.py
+++ b/src/solar.py
@@ -36,6 +36,8 @@ class Solar:
 
         self.lifetime = SolarConstants.LIFETIME
 
+        self._upfront_cost: int | None = None  # to help with overwrites
+
     def __hash__(self):
         return hash((self.latitude,
                      self.longitude,
@@ -73,11 +75,25 @@ class Solar:
 
     @property
     def upfront_cost(self):
-        if self.capacity_kwp <= 4:
-            cost_per_kwp = SolarConstants.COST_PER_KWP_LESS_THAN_4_KW
+        if self._upfront_cost is None:
+            if self.capacity_kwp <= 4:
+                cost_per_kwp = SolarConstants.COST_PER_KWP_LESS_THAN_4_KW
+            else:
+                cost_per_kwp = SolarConstants.COST_PER_KWP_MORE_THAN_4_KW
+            cost = round(self.capacity_kwp * cost_per_kwp, -2)
         else:
-            cost_per_kwp = SolarConstants.COST_PER_KWP_MORE_THAN_4_KW
-        return round(self.capacity_kwp * cost_per_kwp, -2)
+            cost = self._upfront_cost
+
+        return int(cost)
+
+    @upfront_cost.setter
+    def upfront_cost(self, value):
+        if value is not None:
+            value = round(value, -2)
+        self._upfront_cost = value
+
+    def clear_cost_overwrite(self):
+        self.upfront_cost = None
 
     def convert_plan_value_to_value_along_pitch(self, value: float):
         return value / np.cos(np.radians(self.pitch))

--- a/src/solar_questions.py
+++ b/src/solar_questions.py
@@ -73,11 +73,11 @@ def render_solar_assumptions_sidebar(solar_install: 'Solar') -> 'Solar':
 
         st.caption("If you have a better estimate of how much solar could fit on your roof, enter it below:")
 
-        solar_install = render_and_update_solar_inputs(solar_install=solar_install)
+        solar_install = render_solar_overwrite_options(solar_install=solar_install)
     return solar_install
 
 
-def render_and_update_solar_inputs(solar_install: "Solar"):
+def render_solar_overwrite_options(solar_install: "Solar"):
 
     if "number_of_panels" not in st.session_state or st.session_state.number_of_panels_defined_by_dropdown is False:
         st.session_state.number_of_panels = solar_install.number_of_panels

--- a/src/solar_questions.py
+++ b/src/solar_questions.py
@@ -19,16 +19,40 @@ def render() -> "Solar":
         unsafe_allow_html=True,
     )
 
-    polygons = render_map(solar_install)
+    polygons = render_map()
     orientation = render_orientation_questions(solar_install)
-    solar_install = Solar(orientation=orientation, polygons=polygons)
+
+    # if polygons changed (figure out how to persist polygons when page changes)
+    if polygons != solar_install.polygons:
+        print("Setting up solar install based on polygons")
+        solar_install = Solar(orientation=orientation, polygons=polygons)
+        st.session_state.number_of_panels = solar_install.number_of_panels
+        st.session_state.number_of_panels_defined_by_dropdown = False
+    else:
+        print("Not changing default solar install as no polygons drawn")
+        solar_install.orientation = orientation  # in case orientation changed
+
     solar_install = render_solar_assumptions_sidebar(solar_install)
     solar_install = render_results(solar_install)
 
     return solar_install
 
 
-def render_map(solar_install: Solar) -> Optional[List[roof.Polygon]]:
+def get_solar_install_from_session_state_if_exists_or_create_default():
+    if st.session_state["page_state"]["solar"] == {}:
+        solar_install = Solar.create_zero_area_instance()
+        st.session_state.number_of_panels_defined_by_dropdown = False
+        print("Setting up zero solar instance")
+    else:
+        solar_install = st.session_state["page_state"]["solar"]["solar"]
+        st.session_state.number_of_panels_defined_by_dropdown = solar_install.number_of_panels_has_been_overwritten
+        print("Reading in solar install")
+    print(f"number_of_panels_defined_by_dropdown set to {st.session_state.number_of_panels_defined_by_dropdown}")
+    return solar_install
+
+
+def render_map() -> Optional[List[roof.Polygon]]:
+
     try:
         polygons = roof.roof_mapper(800, 400)  # figure out how to save state here
     except KeyError:
@@ -37,11 +61,6 @@ def render_map(solar_install: Solar) -> Optional[List[roof.Polygon]]:
 
     polygons = polygons if polygons else Solar.create_zero_area_instance().polygons
 
-    if "number_of_panels_defined_by_dropdown" not in st.session_state:  # initialise value
-        st.session_state.number_of_panels_defined_by_dropdown = False
-    if polygons != solar_install.polygons:  # if polygons have changed:
-        #  I think 'polygons get reset when you change the page so would need to cache that for this to work
-        st.session_state.number_of_panels_defined_by_dropdown = False
     return polygons
 
 
@@ -57,16 +76,6 @@ def render_orientation_questions(solar_install: Solar):
     return orientation
 
 
-def get_solar_install_from_session_state_if_exists_or_create_default():
-    if st.session_state["page_state"]["solar"] == {}:
-        solar_install = Solar.create_zero_area_instance()
-        st.session_state["page_state"]["solar"] = dict(solar=solar_install)
-        st.session_state.number_of_panels_defined_by_dropdown = False
-    else:
-        solar_install = st.session_state["page_state"]["solar"]["solar"]
-    return solar_install
-
-
 def render_solar_assumptions_sidebar(solar_install: 'Solar') -> 'Solar':
     with st.sidebar:
         st.header("Solar inputs")
@@ -79,31 +88,66 @@ def render_solar_assumptions_sidebar(solar_install: 'Solar') -> 'Solar':
 
 def render_solar_overwrite_options(solar_install: "Solar"):
 
-    if "number_of_panels" not in st.session_state or st.session_state.number_of_panels_defined_by_dropdown is False:
+    if "number_of_panels" not in st.session_state:
         st.session_state.number_of_panels = solar_install.number_of_panels
+        st.session_state.number_of_panels_overwritten = False
+
+    st.number_input(
+        label="Number of panels",
+        min_value=0,
+        max_value=None,
+        key="number_of_panels_overwrite",
+        value=st.session_state.number_of_panels,
+        on_change=overwrite_number_of_panels_in_session_state)
+
+    if st.session_state.number_of_panels_overwritten:
+        solar_install.number_of_panels = st.session_state.number_of_panels
+        write_solar_cost_to_session_state(solar_install)
+        print(f"Behaves as if number of panels changed to {solar_install.number_of_panels} and overwrite flag set to"
+              f"{solar_install.number_of_panels_has_been_overwritten}")
+        st.session_state.number_of_panels_overwritten = False
+
+    if "kwp_per_panel" not in st.session_state:
         st.session_state.kwp_per_panel = solar_install.kwp_per_panel
+        st.session_state.kwp_per_panel_overwritten = False
 
-    solar_install.number_of_panels = st.number_input(
-        label="Number of panels", min_value=0, max_value=None, key="number_of_panels", value=0,
-        on_change=flag_that_number_of_panels_defined_by_dropdown
-    )
+    st.number_input(
+        label="Capacity per panel (kWp)",
+        min_value=0.0,
+        max_value=0.8,
+        key="kwp_per_panel_overwrite",
+        value=st.session_state.kwp_per_panel,
+        on_change=overwrite_kwp_of_panels_in_session_state)
 
-    solar_install.kwp_per_panel = st.number_input(
-        label="Capacity per panel (kWp)", min_value=0.0, max_value=0.8, key="kwp_per_panel",
-        value=SolarConstants.KW_PEAK_PER_PANEL
-    )
+    if st.session_state.kwp_per_panel_overwritten:
+        print("Behaves as if kWp of panels changed")
+        solar_install.kwp_per_panel = st.session_state.kwp_per_panel
+        st.session_state.kwp_per_panel_overwritten = False
+        write_solar_cost_to_session_state(solar_install)
 
     st.session_state["page_state"]["solar"] = dict(solar=solar_install)
 
     return solar_install
 
 
-def flag_that_number_of_panels_defined_by_dropdown():
+def overwrite_number_of_panels_in_session_state():
     st.session_state.number_of_panels_defined_by_dropdown = True
+    print(st.session_state.number_of_panels_overwrite)
+    st.session_state.number_of_panels = st.session_state.number_of_panels_overwrite
+    print(st.session_state.number_of_panels)
+    st.session_state.number_of_panels_overwritten = True
+
+
+def overwrite_kwp_of_panels_in_session_state():
+    st.session_state.kwp_per_panel = st.session_state.kwp_per_panel_overwrite
+    st.session_state.kwp_per_panel_overwritten = True
+
+
+def write_solar_cost_to_session_state(solar_install):
+    st.session_state.solar_cost = solar_install.upfront_cost
 
 
 def render_results(solar_install: Solar):
-
     if solar_install.peak_capacity_kw_out_per_kw_in_per_m2 > 0:
         st.markdown(
             f"<p class='bill-label' style='text-align: center'>We estimate you can fit </p>",

--- a/src/solar_questions.py
+++ b/src/solar_questions.py
@@ -7,9 +7,18 @@ import roof
 from solar import Solar
 
 
-def render() -> "Solar":
+def get_solar_install_from_session_state_if_exists_or_create_default():
+    if "solar_install" not in st.session_state:
+        solar_install = Solar.create_zero_area_instance()
+        st.session_state.number_of_panels_defined_by_dropdown = False
+    else:
+        solar_install = st.session_state.solar_install
+        st.session_state.number_of_panels_defined_by_dropdown = solar_install.number_of_panels_has_been_overwritten
+    return solar_install
+
+
+def render(solar_install: Solar) -> "Solar":
     """Render inputs to calculate solar outputs. If a solar install has already been set up, modify that"""
-    solar_install = get_solar_install_from_session_state_if_exists_or_create_default()
 
     st.header("How much solar power could you generate?")
     st.markdown(
@@ -35,19 +44,6 @@ def render() -> "Solar":
     solar_install = render_solar_assumptions_sidebar(solar_install)
     solar_install = render_results(solar_install)
 
-    return solar_install
-
-
-def get_solar_install_from_session_state_if_exists_or_create_default():
-    if st.session_state["page_state"]["solar"] == {}:
-        solar_install = Solar.create_zero_area_instance()
-        st.session_state.number_of_panels_defined_by_dropdown = False
-        print("Setting up zero solar instance")
-    else:
-        solar_install = st.session_state["page_state"]["solar"]["solar"]
-        st.session_state.number_of_panels_defined_by_dropdown = solar_install.number_of_panels_has_been_overwritten
-        print("Reading in solar install")
-    print(f"number_of_panels_defined_by_dropdown set to {st.session_state.number_of_panels_defined_by_dropdown}")
     return solar_install
 
 

--- a/src/solar_questions.py
+++ b/src/solar_questions.py
@@ -144,7 +144,9 @@ def overwrite_kwp_of_panels_in_session_state():
 
 
 def write_solar_cost_to_session_state(solar_install):
+    solar_install.clear_cost_overwrite()
     st.session_state.solar_cost = solar_install.upfront_cost
+    st.session_state.solar_cost_overwritten = False
 
 
 def render_results(solar_install: Solar):

--- a/tests/test_house.py
+++ b/tests/test_house.py
@@ -162,7 +162,8 @@ def test_upgrade_buildings():
                                   [0.132377, 52.19524]])
     solar_install = solar.Solar(orientation=SolarConstants.ORIENTATIONS['South'],
                                 polygons=[test_polygon])
-    hp_house, solar_house, both_house = retrofit.upgrade_buildings(baseline_house=oil_house,
+
+    solar_house, hp_house, both_house = retrofit.upgrade_buildings(baseline_house=oil_house,
                                                                    upgrade_heating=upgrade_heating,
                                                                    solar_install=solar_install)
     assert hp_house.solar_install.generation.overall.annual_sum_kwh == 0

--- a/tests/test_house.py
+++ b/tests/test_house.py
@@ -24,7 +24,7 @@ def test_envelope():
 
 def test_heating_system():
     profile = pd.Series(index=constants.BASE_YEAR_HOURLY_INDEX, data=1 / 8760)
-    elec_res = building_model.HeatingSystem(name='Electric storage heater',
+    elec_res = building_model.HeatingSystem(name='Direct electric',
                                             efficiency=1.0,
                                             fuel=constants.ELECTRICITY,
                                             hourly_normalized_demand_profile=profile)
@@ -60,7 +60,7 @@ def test_tariff_calculate_annual_cost():
                                    p_per_unit_import=2.0,
                                    p_per_unit_export=50)
     profile = pd.Series(index=constants.BASE_YEAR_HOURLY_INDEX, data=1 / 8760)
-    elec_res = building_model.HeatingSystem(name='Electric storage heater',
+    elec_res = building_model.HeatingSystem(name='Direct electric',
                                             efficiency=1.0,
                                             fuel=constants.ELECTRICITY,
                                             hourly_normalized_demand_profile=profile)

--- a/tests/test_house.py
+++ b/tests/test_house.py
@@ -164,7 +164,7 @@ def test_upgrade_buildings():
                                 polygons=[test_polygon])
     hp_house, solar_house, both_house = retrofit.upgrade_buildings(baseline_house=oil_house,
                                                                    upgrade_heating=upgrade_heating,
-                                                                   upgrade_solar=solar_install)
+                                                                   solar_install=solar_install)
     assert hp_house.solar_install.generation.overall.annual_sum_kwh == 0
     assert both_house.solar_install.generation.overall.annual_sum_kwh < 0  # export defined as negative
     np.testing.assert_almost_equal(both_house.consumption_per_fuel['electricity'].imported.annual_sum_kwh


### PR DESCRIPTION
Give user the ability to overwrite the costs. Involved significant changes in state management overall, with state being explicitly read and written from main.

Split solar instructions out into subsections